### PR TITLE
修正 docker/pkg/log 的 dependency 問題

### DIFF
--- a/api/common.go
+++ b/api/common.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/docker/docker/engine"
-	"github.com/docker/docker/pkg/log"
+	log "github.com/Sirupsen/logrus"
 	"github.com/docker/docker/pkg/parsers"
 	"github.com/docker/docker/pkg/version"
 )

--- a/api/server/server_docker.go
+++ b/api/server/server_docker.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/docker/docker/engine"
 	"github.com/docker/docker/pkg/listenbuffer"
-	"github.com/docker/docker/pkg/log"
+	log "github.com/Sirupsen/logrus"
 	"github.com/docker/docker/pkg/systemd"
 	"github.com/docker/docker/pkg/version"
 	"github.com/hacking-thursday/sysd/api"

--- a/api/server2/server.go
+++ b/api/server2/server.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/docker/docker/pkg/log"
+	log "github.com/Sirupsen/logrus"
 	flag "github.com/docker/docker/pkg/mflag"
 	"github.com/gorilla/mux"
 	"github.com/tsaikd/KDGoLib/env"

--- a/mods/arp/main.go
+++ b/mods/arp/main.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/docker/docker/pkg/log"
+	log "github.com/Sirupsen/logrus"
 	"github.com/docker/docker/pkg/version"
 	"github.com/hacking-thursday/sysd/mods"
 )

--- a/mods/battery/battery_linux.go
+++ b/mods/battery/battery_linux.go
@@ -1,7 +1,7 @@
 package battery
 
 import (
-    "github.com/docker/docker/pkg/log"
+    log "github.com/Sirupsen/logrus"
     "github.com/docker/docker/pkg/version"
     "github.com/hacking-thursday/sysd/mods"
     "net/http"

--- a/mods/cpuinfo/main.go
+++ b/mods/cpuinfo/main.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/docker/docker/pkg/log"
+	log "github.com/Sirupsen/logrus"
 	"github.com/docker/docker/pkg/version"
 	"github.com/hacking-thursday/sysd/mods"
 )

--- a/mods/createRouter.go
+++ b/mods/createRouter.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/docker/docker/pkg/log"
+	log "github.com/Sirupsen/logrus"
 	flag "github.com/docker/docker/pkg/mflag"
 	"github.com/docker/docker/pkg/version"
 	"github.com/gorilla/mux"

--- a/mods/funcs.go
+++ b/mods/funcs.go
@@ -2,7 +2,7 @@ package mods
 
 import (
 	"encoding/json"
-	"github.com/docker/docker/pkg/log"
+	log "github.com/Sirupsen/logrus"
 	"net/http"
 	"strings"
 )

--- a/mods/info2/info2.go
+++ b/mods/info2/info2.go
@@ -4,7 +4,7 @@ package info2
 
 import (
 	"github.com/docker/docker/engine"
-	"github.com/docker/docker/pkg/log"
+	log "github.com/Sirupsen/logrus"
 	"github.com/docker/docker/pkg/version"
 	"github.com/hacking-thursday/sysd/mods"
 	"net/http"

--- a/mods/meminfo/main.go
+++ b/mods/meminfo/main.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/docker/docker/pkg/log"
+	log "github.com/Sirupsen/logrus"
 	"github.com/docker/docker/pkg/version"
 	"github.com/hacking-thursday/sysd/mods"
 )

--- a/mods/memstats/memstats.go
+++ b/mods/memstats/memstats.go
@@ -1,7 +1,7 @@
 package memstats
 
 import (
-	"github.com/docker/docker/pkg/log"
+	log "github.com/Sirupsen/logrus"
 	"github.com/docker/docker/pkg/version"
 	"github.com/hacking-thursday/sysd/mods"
 	"net/http"

--- a/mods/mods.go
+++ b/mods/mods.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/docker/docker/pkg/log"
+	log "github.com/Sirupsen/logrus"
 	"github.com/docker/docker/pkg/version"
 )
 

--- a/mods/net/net.go
+++ b/mods/net/net.go
@@ -4,7 +4,7 @@ package net
 
 import (
     "github.com/docker/docker/engine"
-    "github.com/docker/docker/pkg/log"
+    log "github.com/Sirupsen/logrus"
     "github.com/docker/docker/pkg/version"
     "github.com/hacking-thursday/sysd/mods"
     "net/http"

--- a/mods/ping/ping.go
+++ b/mods/ping/ping.go
@@ -1,7 +1,7 @@
 package ping
 
 import (
-	"github.com/docker/docker/pkg/log"
+	log "github.com/Sirupsen/logrus"
 	"github.com/docker/docker/pkg/version"
 	"github.com/hacking-thursday/sysd/mods"
 	"net/http"

--- a/mods/route/main.go
+++ b/mods/route/main.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/docker/docker/pkg/log"
+	log "github.com/Sirupsen/logrus"
 	"github.com/docker/docker/pkg/version"
 	"github.com/hacking-thursday/sysd/mods"
 )

--- a/mods/sample/sample.go
+++ b/mods/sample/sample.go
@@ -1,7 +1,7 @@
 package sample
 
 import (
-	"github.com/docker/docker/pkg/log"
+	log "github.com/Sirupsen/logrus"
 	"github.com/docker/docker/pkg/version"
 	"github.com/hacking-thursday/sysd/mods"
 	"net/http"

--- a/mods/sysfs/main.go
+++ b/mods/sysfs/main.go
@@ -9,7 +9,7 @@ import (
 	"path"
 	"path/filepath"
 
-	"github.com/docker/docker/pkg/log"
+	log "github.com/Sirupsen/logrus"
 	"github.com/docker/docker/pkg/version"
 	"github.com/hacking-thursday/sysd/mods"
 )

--- a/mods/sysinfo/sysinfo_linux.go
+++ b/mods/sysinfo/sysinfo_linux.go
@@ -1,7 +1,7 @@
 package sysinfo
 
 import (
-	"github.com/docker/docker/pkg/log"
+	log "github.com/Sirupsen/logrus"
 	"github.com/docker/docker/pkg/version"
 	"github.com/hacking-thursday/sysd/mods"
 	"net/http"

--- a/mods/ui/main.go
+++ b/mods/ui/main.go
@@ -1,7 +1,7 @@
 package ui
 
 import (
-	"github.com/docker/docker/pkg/log"
+	log "github.com/Sirupsen/logrus"
 	"github.com/docker/docker/pkg/version"
 	"github.com/hacking-thursday/sysd/mods"
 	"net/http"


### PR DESCRIPTION
docker 將 log 從 "github.com/docker/docker/pkg/log" 改為 log "github.com/Sirupsen/logrus"
這裡將使用到 log 的部份都調整過來
